### PR TITLE
feat(copilot): setup communication with other extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,77 +1,90 @@
 {
-    "name": "miranum-copilot",
-    "displayName": "miranum-copilot",
-    "description": "A copilot that helps BPM-Developer.",
-    "license": "Apache-2.0",
-    "version": "0.1.0",
-    "publisher": "miragon-gmbh",
-    "preview": true,
-    "homepage": "https://www.miranum.io/",
-    "galleryBanner": {
-        "color": "#F0F8FF",
-        "theme": "light"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/FlowSquad/miranum-copilot.git"
-    },
-    "bugs": {
-        "url": "https://github.com/FlowSquad/miranum-copilot/issues"
-    },
-    "engines": {
-        "vscode": "^1.76.0"
-    },
-    "icon": "images/miranum_logo.png",
-    "categories": [
-        "Other"
-    ],
-    "keywords": [
-        "AI",
-        "BPM",
-        "BPMN",
-        "ChatGPT",
-        "Copilot"
-    ],
-    "activationEvents": [
-        "onWebviewPanel:copilot"
-    ],
-    "main": "./dist/main.js",
-    "contributes": {
-        "commands": [
-            {
-                "command": "copilot.start",
-                "title": "Miranum Copilot",
-                "category": "Miranum Copilot"
-            }
-        ]
-    },
-    "scripts": {
-        "vscode:prepublish": "npm run compile",
-        "pretest": "npm run compile && npm run lint",
-        "lint": "eslint src --ext ts",
-        "test": "node ./dist/test/runTest.js",
-        "build": "npm run esbuild-base -- --minify && npm run web",
-        "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=dist/main.js --external:vscode --format=cjs --platform=node",
-        "esbuild": "npm run esbuild-base -- --sourcemap",
-        "esbuild-dev": "npm run esbuild-base -- --sourcemap --watch",
-        "web": "vite build --config src/web/vite.config.js",
-        "web-dev": "vite build --config src/web/vite.config.js --watch"
-    },
-    "devDependencies": {
-        "@types/glob": "^8.1.0",
-        "@types/mocha": "^10.0.1",
-        "@types/node": "16.x",
-        "@types/vscode": "^1.76.0",
-        "@types/vscode-webview": "^1.57.1",
-        "@typescript-eslint/eslint-plugin": "^5.59.1",
-        "@typescript-eslint/parser": "^5.59.1",
-        "@vscode/test-electron": "^2.3.0",
-        "esbuild": "^0.17.18",
-        "eslint": "^8.39.0",
-        "glob": "^8.1.0",
-        "mocha": "^10.2.0",
-        "prettier": "^2.8.8",
-        "typescript": "^5.0.4",
-        "vite": "^4.3.3"
-    }
+  "name": "miranum-copilot",
+  "displayName": "miranum-copilot",
+  "description": "A copilot that helps BPM-Developer.",
+  "license": "Apache-2.0",
+  "version": "0.1.0",
+  "publisher": "miragon-gmbh",
+  "preview": true,
+  "homepage": "https://www.miranum.io/",
+  "galleryBanner": {
+    "color": "#F0F8FF",
+    "theme": "light"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FlowSquad/miranum-copilot.git"
+  },
+  "bugs": {
+    "url": "https://github.com/FlowSquad/miranum-copilot/issues"
+  },
+  "engines": {
+    "vscode": "^1.76.0"
+  },
+  "icon": "images/miranum_logo.png",
+  "categories": [
+    "Other"
+  ],
+  "keywords": [
+    "AI",
+    "BPM",
+    "BPMN",
+    "ChatGPT",
+    "Copilot"
+  ],
+  "extensionDependencies": [
+    "miragon-gmbh.mock-te"
+  ],
+  "activationEvents": [
+    "onWebviewPanel:copilot"
+  ],
+  "main": "./dist/main.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "copilot.start",
+        "title": "Miranum Copilot: Start",
+        "category": "Miranum Copilot"
+      },
+      {
+        "command": "copilot.setBpmn",
+        "title": "Miranum Copilot: Set BPMN",
+        "category": "Miranum Copilot"
+      },
+      {
+        "command": "copilot.getBpmn",
+        "title": "Miranum Copilot: Get BPMN",
+        "category": "Miranum Copilot"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "pretest": "npm run compile && npm run lint",
+    "lint": "eslint src --ext ts",
+    "test": "node ./dist/test/runTest.js",
+    "build": "npm run esbuild-base -- --minify && npm run web",
+    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=dist/main.js --external:vscode --format=cjs --platform=node",
+    "esbuild": "npm run esbuild-base -- --sourcemap",
+    "esbuild-dev": "npm run esbuild-base -- --sourcemap --watch",
+    "web": "vite build --config src/web/vite.config.js",
+    "web-dev": "vite build --config src/web/vite.config.js --watch"
+  },
+  "devDependencies": {
+    "@types/glob": "^8.1.0",
+    "@types/mocha": "^10.0.1",
+    "@types/node": "16.x",
+    "@types/vscode": "^1.76.0",
+    "@types/vscode-webview": "^1.57.1",
+    "@typescript-eslint/eslint-plugin": "^5.59.1",
+    "@typescript-eslint/parser": "^5.59.1",
+    "@vscode/test-electron": "^2.3.0",
+    "esbuild": "^0.17.18",
+    "eslint": "^8.39.0",
+    "glob": "^8.1.0",
+    "mocha": "^10.2.0",
+    "prettier": "^2.8.8",
+    "typescript": "^5.0.4",
+    "vite": "^4.3.3"
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import { Logger } from "./Logger";
 
 export function activate(context: ExtensionContext) {
     let disposable = commands.registerCommand("copilot.start", () => {
-        CopilotPanel.createOrShow(context.extensionUri);
+        CopilotPanel.createOrShow(context);
     });
 
     context.subscriptions.push(Logger.get("Miranum: Copilot"));


### PR DESCRIPTION
**Issue**
To get help from ChatGPT on the BPMN model that is being edited, we need access to the XML. This means that we need to communicate with the Miranum Modeler. This PR demonstrates how this can be done.

**Description**
For illustration purposes, a [repo](https://github.com/peterhnm/vscode-mock-text-editor) was set up to replicate a VS Code Custom Text Editor Extension. The README of this repo explains what was done.


**Checklist**
* [x] Code is easy to understand
* [x] No obvious errors or bugs
* [x] CI/CD Pipelines did run successfully
* [x] Tests were implemented
* [x] Documentation was created
* [x] [Semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and PR names have been used
* [x] [Emoji Guide](https://github.com/erikthedeveloper/code-review-emoji-guide) for PR Reviews has been used (to be checked by the reviewer)
