### PR TITLE
chore(repo): replace FlowSquad with Miragon

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,32 +12,28 @@
 <br />
 <div align="center">
     <a href="#">
-        <img src="https://raw.githubusercontent.com/FlowSquad/miranum-copilot/main/images/miranum_logo.png" alt="Logo" height="120">
+        <img src="https://raw.githubusercontent.com/Miragon/miranum-copilot/main/images/miranum_logo.png" alt="Logo" height="120">
     </a>
     <h3 ><a href="https://miranum.com/">Miranum IDE</a> <i>by <a href="https://miragon.io/">Miragon</a></i></h3>
     <p>
         <i>One IDE for everything!</i>
         <br />
-        <a href="https://github.com/FlowSquad/miranum-json-forms/issues">Report Bug</a>
+        <a href="https://github.com/Miragon/miranum-json-forms/issues">Report Bug</a>
         ·
-        <a href="https://github.com/FlowSquad/miranum-json-forms/pulls">Request Feature</a>
+        <a href="https://github.com/Miragon/miranum-json-forms/pulls">Request Feature</a>
     </p>
 </div>
 
-
 ## About The Project [![Version][version-shield]][version-url] [![Installs][installs-shield]][installs-url]
 
-Miranum IDE is a collection of "VS Code Plugins" that allows you to edit, manage and access all artifacts for your 
+Miranum IDE is a collection of "VS Code Plugins" that allows you to edit, manage and access all artifacts for your
 process application in one place.
 Please find our official docs [here](https://miranum.com/docs/components/miranum-ide/intro-miranum-ide).
-
 
 **Miranum Copilot** is one component of our collection of *VS Code Plugins*.
 The copilot should help experienced but also new **BPM Developers** in there tasks.
 
-
 ## Features
-
 
 ## Contributing
 
@@ -54,18 +50,31 @@ Distributed under the [Apache License Version 2.0](LICENSE).
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
-[contributors-shield]: https://img.shields.io/github/contributors/FlowSquad/miranum-copilot.svg?style=for-the-badge
-[contributors-url]: https://github.com/FlowSquad/miranum-copilot/graphs/contributors
-[forks-shield]: https://img.shields.io/github/forks/FlowSquad/miranum-copilot.svg?style=for-the-badge
-[forks-url]: https://github.com/FlowSquad/miranum-copilot/network/members
-[stars-shield]: https://img.shields.io/github/stars/FlowSquad/miranum-copilot.svg?style=for-the-badge
-[stars-url]: https://github.com/FlowSquad/miranum-copilot/stargazers
-[issues-shield]: https://img.shields.io/github/issues/FlowSquad/miranum-copilot.svg?style=for-the-badge
-[issues-url]: https://github.com/FlowSquad/miranum-copilot/issues
-[license-shield]: https://img.shields.io/github/license/FlowSquad/miranum-copilot.svg?style=for-the-badge
-[license-url]: https://github.com/FlowSquad/miranum-copilot/blob/main/LICENSE
+
+[contributors-shield]: https://img.shields.io/github/contributors/Miragon/miranum-copilot.svg?style=for-the-badge
+
+[contributors-url]: https://github.com/Miragon/miranum-copilot/graphs/contributors
+
+[forks-shield]: https://img.shields.io/github/forks/Miragon/miranum-copilot.svg?style=for-the-badge
+
+[forks-url]: https://github.com/Miragon/miranum-copilot/network/members
+
+[stars-shield]: https://img.shields.io/github/stars/Miragon/miranum-copilot.svg?style=for-the-badge
+
+[stars-url]: https://github.com/Miragon/miranum-copilot/stargazers
+
+[issues-shield]: https://img.shields.io/github/issues/Miragon/miranum-copilot.svg?style=for-the-badge
+
+[issues-url]: https://github.com/Miragon/miranum-copilot/issues
+
+[license-shield]: https://img.shields.io/github/license/Miragon/miranum-copilot.svg?style=for-the-badge
+
+[license-url]: https://github.com/Miragon/miranum-copilot/blob/main/LICENSE
 
 [version-shield]: https://img.shields.io/visual-studio-marketplace/v/miragon-gmbh.miranum-copilot
+
 [version-url]: https://marketplace.visualstudio.com/items?itemName=miragon-gmbh.miranum-copilot
+
 [installs-shield]: https://img.shields.io/visual-studio-marketplace/i/miragon-gmbh.miranum-copilot
+
 [installs-url]: https://marketplace.visualstudio.com/items?itemName=miragon-gmbh.miranum-copilot

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,17 +1,19 @@
 # Getting started
 
-> **_NOTE:_** At some point in the future, this repository will be migrated to our [main repository](https://github.com/FlowSquad/miranum-ide).
- 
+> **_NOTE:_** At some point in the future, this repository will be migrated to
+> our [main repository](https://github.com/Miragon/miranum-ide).
+
 ### Built With
 
- 
 ### Contributing
 
 Contributions are what make the open source community such an amazing place to learn, inspire, and create.
 Any contributions you make are **greatly appreciated**.
-Please use semantic commit messages as described in [here](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716).
+Please use semantic commit messages as described
+in [here](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716).
 
-If you have a suggestion that would make this better, please open an issue with the tag "enhancement", fork the repo and create a pull request. You can also simply open an issue with the tag "enhancement".
+If you have a suggestion that would make this better, please open an issue with the tag "enhancement", fork the repo and
+create a pull request. You can also simply open an issue with the tag "enhancement".
 Don't forget to give the project a star! Thanks again!
 
 1. Open an issue with the tag "enhancement"
@@ -22,6 +24,7 @@ Don't forget to give the project a star! Thanks again!
 6. Open a Pull Request
 
 ### Project structure
+
 ```
 .
 ├── package.json
@@ -43,20 +46,25 @@ Don't forget to give the project a star! Thanks again!
 ```
 
 ### Quickstart
+
 ```shell
-git clone https://github.com/FlowSquad/miranum-copilot.git
+git clone https://github.com/Miragon/miranum-copilot.git
 cd miranum-copilot
 ```
+
 ```shell
 npm install
 npm run build
 ```
+
 ```shell
 code .
 ```
+
 Open `Extension Host` with `F5` and open the example folder.
 
 ### Development
+
 ```shell
 npm run esbuild-watch
 ```

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/FlowSquad/miranum-copilot.git"
+        "url": "https://github.com/Miragon/miranum-copilot.git"
     },
     "bugs": {
-        "url": "https://github.com/FlowSquad/miranum-copilot/issues"
+        "url": "https://github.com/Miragon/miranum-copilot/issues"
     },
     "engines": {
         "vscode": "^1.76.0"


### PR DESCRIPTION
**Description**
Because of the rebranding and the change in the orginization repo we have to replace `FlowSquad` with `Miragon`.

**Checklist**
* [x] CI/CD Pipelines did run successfully
* [x] Documentation was created
* [x] [Semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and PR names have been used
* [x] [Emoji Guide](https://github.com/erikthedeveloper/code-review-emoji-guide) for PR Reviews has been used (to be checked by the reviewer)
